### PR TITLE
Fix corejs version warning

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -30,6 +30,7 @@ module.exports = function(api) {
         {
           forceAllTransforms: true,
           useBuiltIns: 'entry',
+          corejs: 3,
           modules: false,
           exclude: ['transform-typeof-symbol']
         }


### PR DESCRIPTION
Fix this warning:

```
WARNING: We noticed you're using the `useBuiltIns` option without
declaring a core-js version. Currently, we assume version 2.x when
no version is passed. Since this default version will likely change
in future versions of Babel, we recommend explicitly setting the core-js
version you are using via the `corejs` option.
```